### PR TITLE
Add initial agentic pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # DIP
-Diplomatic Intelligence Platform that addresses critical U.S. national security challenges through advanced AI technology
+
+Diplomatic Intelligence Platform (DIP) is a demonstration of an agentic
+architecture that brings together multiple data modalities in order to aid
+strategic decision making. The project shows how satellite imagery, media
+monitoring, voice communication transcripts and economic indicators could be
+processed in a unified workflow.
+
+## Structure
+
+The core logic lives in the `dip` package:
+
+- `data_sources.py` – placeholder classes for different data streams.
+- `processing.py` – simple analyzers that mimic AI model processing.
+- `agents.py` – agent classes that perform collection, analysis and synthesis.
+- `pipeline.py` – wires the agents together into an end‑to‑end pipeline.
+
+`main.py` provides a small runnable example using dummy components.
+
+## Running
+
+The example requires Python 3.12+. With a local Python environment
+active, run:
+
+```bash
+python main.py
+```
+
+This will execute the demo pipeline and print a synthesized report from
+the placeholder data sources.

--- a/dip/agents.py
+++ b/dip/agents.py
@@ -1,0 +1,50 @@
+"""Agentic workflow components for the Diplomatic Intelligence Platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Any, List
+
+from .data_sources import DataSource
+from .processing import Analyzer, aggregate
+
+
+@dataclass
+class Agent:
+    """Base class for an agent in the workflow."""
+
+    def run(self) -> Iterable[Any]:
+        raise NotImplementedError
+
+
+@dataclass
+class CollectionAgent(Agent):
+    """Agent responsible for gathering data."""
+
+    sources: List[DataSource]
+
+    def run(self) -> Iterable[Any]:
+        for source in self.sources:
+            yield from source.fetch()
+
+
+@dataclass
+class AnalysisAgent(Agent):
+    """Agent responsible for analyzing collected data."""
+
+    analyzer: Analyzer
+    inbox: Iterable[Any]
+
+    def run(self) -> Iterable[Any]:
+        for item in self.inbox:
+            yield self.analyzer.process(item)
+
+
+@dataclass
+class SynthesisAgent(Agent):
+    """Agent responsible for synthesizing analysis results."""
+
+    inbox: Iterable[Any]
+
+    def run(self) -> Any:
+        return aggregate(self.inbox)

--- a/dip/data_sources.py
+++ b/dip/data_sources.py
@@ -1,0 +1,50 @@
+"""Data source definitions for the Diplomatic Intelligence Platform."""
+
+from dataclasses import dataclass
+from typing import Iterable, Any
+
+
+@dataclass
+class SatelliteImagery:
+    """Placeholder for satellite imagery data."""
+    image_path: str
+
+
+@dataclass
+class MediaArticle:
+    """Represents a piece of media content."""
+    language: str
+    text: str
+
+
+@dataclass
+class VoiceCommunication:
+    """Represents captured voice communication metadata."""
+    transcript: str
+    speaker: str
+
+
+@dataclass
+class EconomicIndicator:
+    """Represents economic data points."""
+    name: str
+    value: float
+
+
+class DataSource:
+    """Abstract interface for data sources."""
+
+    def fetch(self) -> Iterable[Any]:
+        """Fetch new data items from the source."""
+        raise NotImplementedError
+
+
+class DummyDataSource(DataSource):
+    """Example implementation that yields placeholder data."""
+
+    def fetch(self) -> Iterable[Any]:
+        # In a real system this would connect to external APIs or data feeds
+        yield SatelliteImagery(image_path="/path/to/image.png")
+        yield MediaArticle(language="en", text="Example news article")
+        yield VoiceCommunication(transcript="Hello world", speaker="Analyst")
+        yield EconomicIndicator(name="GDP", value=1.0)

--- a/dip/pipeline.py
+++ b/dip/pipeline.py
@@ -1,0 +1,27 @@
+"""Orchestration pipeline for the Diplomatic Intelligence Platform."""
+
+from typing import Any, Iterable
+
+from .agents import CollectionAgent, AnalysisAgent, SynthesisAgent
+from .data_sources import DummyDataSource
+from .processing import DummyAnalyzer
+
+
+class Pipeline:
+    """High-level pipeline that wires agents together."""
+
+    def __init__(self) -> None:
+        self.collection_agent = CollectionAgent(sources=[DummyDataSource()])
+        self.analysis_agent: AnalysisAgent | None = None
+        self.synthesis_agent: SynthesisAgent | None = None
+
+    def build(self) -> None:
+        collected = list(self.collection_agent.run())
+        self.analysis_agent = AnalysisAgent(analyzer=DummyAnalyzer(), inbox=collected)
+        analysis_results = list(self.analysis_agent.run())
+        self.synthesis_agent = SynthesisAgent(inbox=analysis_results)
+
+    def run(self) -> Iterable[Any]:
+        if self.synthesis_agent is None:
+            self.build()
+        yield self.synthesis_agent.run()

--- a/dip/processing.py
+++ b/dip/processing.py
@@ -1,0 +1,24 @@
+"""Data processing utilities for the Diplomatic Intelligence Platform."""
+
+from typing import Iterable, Any
+
+
+class Analyzer:
+    """Base class for analytic components."""
+
+    def process(self, item: Any) -> Any:
+        """Process a single data item and return the result."""
+        raise NotImplementedError
+
+
+class DummyAnalyzer(Analyzer):
+    """Simple analyzer that echoes the input data."""
+
+    def process(self, item: Any) -> Any:
+        # In a real system this would apply machine learning models
+        return {"input": item, "analysis": "placeholder"}
+
+
+def aggregate(results: Iterable[Any]) -> Any:
+    """Combine analysis results into a unified report."""
+    return list(results)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+"""Entry point for the Diplomatic Intelligence Platform demo."""
+
+from dip.pipeline import Pipeline
+
+
+def main() -> None:
+    pipeline = Pipeline()
+    for report in pipeline.run():
+        print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a `dip` package containing the agent-based pipeline
- provide a runnable `main.py`
- document project structure and running instructions
- ignore Python cache files

## Testing
- `pytest`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_b_683df6f8fdf08328a615be29dc630c18